### PR TITLE
chore: fix broken links in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ if image assets are added to a given section you must provide both a dark and li
 
 1. Navigate to the desired page to update (e.g. `/pages/docs/anchor-system/overview.mdx`)
 2. Make applicable changes
-3. Test those changes locally `yarn dev`
+3. Test those changes locally `yarn install && yarn dev`
 
 **Adding content for existing section**
 
@@ -43,7 +43,7 @@ if image assets are added to a given section you must provide both a dark and li
 2. Create a new mdx file that represents new page for desired section (e.g. `advanced.mdx`)
 3. Write desired content for the new mdx file 
 4. Update the `_meta.json` file within the section directory to include your new page into the navigation
-5. Test those changes locally `yarn dev`
+5. Test those changes locally `yarn install && yarn dev`
 
 **Note:** To create a section with dropdown navigation, simply create a folder and specify the new navigation in `_meta.json`, create new your new files in the new directory along with its own `_meta.json` to outline the desired 
 navigation.  

--- a/components/QuickStart.tsx
+++ b/components/QuickStart.tsx
@@ -92,7 +92,7 @@ export const DappsArea = () => {
       <DetailedFeatureLink
         feature={{
           Icon: CubeIcon,
-          description: `Private cross-chain bridge. Dedicated UI for moving digital assets cross-chain and privately.`,
+          description: `Private cross-chain bridge. Dedicated UI for moving digital assets privately cross-chain.`,
           name: "Hubble Bridge",
         }}
         href="https://development-hubble-bridge.netlify.app/"

--- a/pages/docs/anchor-system/architecture.mdx
+++ b/pages/docs/anchor-system/architecture.mdx
@@ -1,11 +1,11 @@
 ---
-title: Protocol
+title: System
 description: Webb Anchor System is an interoperable zero-knowledge proof based system
 ---
 
 import AnchorArchitecture from '../../../components/images/AnchorArchitecture'
 
-# Protocol
+# System
 
 Given **_G=(A,E)_** a graph of anchors and edges between them. Fix an element schema/structure **_S_** for element hashes inserted into
 the anchors’ merkle trees.
@@ -43,7 +43,7 @@ our private bridge protocol. The modifications can be summarized as:
   - Anchors can mint/burn the underlying token being deposited and withdrawn.
 - Augmenting ChainBridge's Bridge into a private bridge protocol.
   - We create a new AnchorHandler which modifiers the edge list of Anchors needing updates.
-  - We augment the Bridge relayers w/ a multi-party threshold signing scheme, so that one or many threshold networks can govern the bridge.
+  - We augment the Bridge relayers with a multi-party threshold signing scheme, so that one or many threshold networks can govern the bridge.
 
 ## Further reading
 

--- a/pages/docs/anchor-system/overview.mdx
+++ b/pages/docs/anchor-system/overview.mdx
@@ -133,7 +133,7 @@ In practice, the oracle and relayers roles are synergistic and often taken out b
 remark about these roles separately, we often consider them as being undertaken by the same party. We use the terms interchangeably
 to represent the network that provides **both** relaying and oracle services in the Anchor System.
 
-**References**
+### Further reading
 
 - [Merkle Tree](https://en.wikipedia.org/wiki/Merkle_tree)
 - [Unspent Transaction Output](https://en.wikipedia.org/wiki/Unspent_transaction_output)

--- a/pages/docs/tangle-network/overview.mdx
+++ b/pages/docs/tangle-network/overview.mdx
@@ -9,7 +9,8 @@ import FullWebbCTA from "../../../components/FullWebbCTA";
 # Overview
 
 The Tangle Network is a next-gen TSS based blockchain with a powerful threshold signature governance system for operating,
-governing, maintaining, growing, powering cross-chain applications.
+governing, maintaining, growing, powering cross-chain applications. Want to learn more about the Tangle Network? Checkout the 
+project details at [https://parachains.info/details/tangle_network](https://parachains.info/details/tangle_network?preview=1).
 
 ## Test Networks
 


### PR DESCRIPTION
Changes introduced in this PR:
- Updates readme 
- Adds parachain info link
- Fixes grammar