### PR TITLE
fix: Fix outdated startup commands

### DIFF
--- a/pages/docs/ecosystem-roles/validator/deploy-with-docker/full-node.mdx
+++ b/pages/docs/ecosystem-roles/validator/deploy-with-docker/full-node.mdx
@@ -9,7 +9,7 @@ import Callout from "../../../../../components/Callout";
 
 An Tangle node can be spun up quickly using Docker. For more information on installing Docker,
 please visit the official Docker [docs](https://docs.docker.com/get-docker/). When connecting to Tangle on Kusama, it will take a few days to completely
-sync the embedded relay chain. Make sure that your system meets the requirements which can read [here](/docs/tangle-network/node-operators/requirements).
+sync the embedded relay chain. Make sure that your system meets the requirements which can read [here](https://docs.webb.tools/docs/ecosystem-roles/validator/requirements/).
 
 ## Using Docker
 
@@ -56,8 +56,7 @@ docker run --rm -it -v /var/lib/tangle/:/data ghcr.io/webb-tools/tangle/tangle-s
   --name="YOUR-NODE-NAME" \
   --base-path /data \
   --rpc-cors all \
-  --ws-external \
-  --ws-port 9946
+  --port 9946
 ```
 
 <Callout type="info">

--- a/pages/docs/ecosystem-roles/validator/systemd/full-node.mdx
+++ b/pages/docs/ecosystem-roles/validator/systemd/full-node.mdx
@@ -48,7 +48,6 @@ ExecStart=/usr/bin/tangle-standalone \
   --name <NODE-NAME> \
   --chain tangle-testnet \
   --node-key-file "/home/<USERNAME>/node-key" \
-  --port 30333 \
   --rpc-cors all \
   --port 9946 \
   --no-mdns

--- a/pages/docs/ecosystem-roles/validator/systemd/full-node.mdx
+++ b/pages/docs/ecosystem-roles/validator/systemd/full-node.mdx
@@ -9,7 +9,7 @@ You can run your full node as a systemd process so that it will automatically re
 or crashes (and helps to avoid getting slashed!).
 
 Before following this guide you should have already set up your machines environment, installed the dependencies, and
-compiled the Tangle binary. If you have not done so, please refer to the [Requirements](/docs/tangle-network/node-operators/requirements) page.
+compiled the Tangle binary. If you have not done so, please refer to the [Requirements](https://docs.webb.tools/docs/ecosystem-roles/validator/requirements/) page.
 
 ## System service setup
 
@@ -46,12 +46,11 @@ RestartSec=3
 ExecStart=/usr/bin/tangle-standalone \
   --base-path /data/full-node \
   --name <NODE-NAME> \
-  --chain tangle \
+  --chain tangle-testnet \
   --node-key-file "/home/<USERNAME>/node-key" \
   --port 30333 \
   --rpc-cors all \
-  --ws-external \
-  --ws-port 9946 \
+  --port 9946 \
   --no-mdns
 
 [Install]

--- a/pages/docs/ecosystem-roles/validator/systemd/validator-node.mdx
+++ b/pages/docs/ecosystem-roles/validator/systemd/validator-node.mdx
@@ -123,7 +123,7 @@ RestartSec=3
 ExecStart=/usr/bin/tangle-standalone \
   --base-path /data/validator/<USERNAME> \
   --name <NODE-NAME> \
-  --chain tangle \
+  --chain tangle-testnet \
   --node-key-file "/home/<USERNAME>/node-key" \
   --port 30333 \
   --validator \

--- a/pages/docs/ecosystem-roles/validator/systemd/validator-node.mdx
+++ b/pages/docs/ecosystem-roles/validator/systemd/validator-node.mdx
@@ -125,7 +125,7 @@ ExecStart=/usr/bin/tangle-standalone \
   --name <NODE-NAME> \
   --chain tangle-testnet \
   --node-key-file "/home/<USERNAME>/node-key" \
-  --port 30333 \
+  --port 9944 \
   --validator \
   --no-mdns
 


### PR DESCRIPTION
## Summary of changes

Fixes outdated node startup commands

### Proposed area of change

_Put an `x` in the boxes that apply._

- [ ] `Overview`
- [ ] `Anchor System`
- [ ] `dApps`
- [X] `Tangle`
- [ ] `Protocols`
- [ ] `Relayers`

### Reference issue to close (if applicable)

_Specify any issues that can be closed from these changes (e.g. Closes #233)._

- Closes #119 #121 #120 

---

### Code Checklist

- [X] I have tested that prove my changes are working as intended
- [ ] I have added necessary documentation (if appropriate)
