### PR TITLE
Update netlify.toml to redirect broken docs.webb links to tangle docs

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -7,3 +7,15 @@
   to = "/docs"
   status = 301
   force = true
+
+  [[redirects]]
+from = "/docs/ecosystem-roles/validator/*"
+to = "https://docs.tangle.tools/:splat"
+status = 301
+force = true
+
+[[redirects]]
+from = "/docs/tangle-network/*"
+to = "https://docs.tangle.tools/:splat"
+status = 301
+force = true


### PR DESCRIPTION
## Summary of changes

Adds redirect rules to be processed by netlify. Tested redirects and they work.

Repairs most of the issues in https://github.com/webb-tools/webb-dapp/issues/1961



---

### Code Checklist

- [x] I have tested that prove my changes are working as intended
- [ ] I have added necessary documentation (if appropriate)
